### PR TITLE
Add CI Pipeline for .NET Project Using Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,24 @@
+pipeline {
+    agent any
+
+    stages {
+
+        stage('Restore') {
+            steps {
+                sh 'dotnet restore'
+            }
+        }
+
+        stage('Build') {
+            steps {
+                sh 'dotnet build --no-restore'
+            }
+        }
+
+        stage('Test') {
+            steps {
+                sh 'dotnet test --no-build --verbosity normal'
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a Jenkins pipeline to automate the build, test, and restore process for the .NET project. The pipeline consists of the following stages:

* **Restore:** Restores the project dependencies using `dotnet restore`.
* **Build:** Builds the project without re-restoring dependencies using `dotnet build --no-restore`.
* **Test:** Runs the unit tests without rebuilding the project using `dotnet test --no-build --verbosity normal`.

This pipeline ensures continuous integration by verifying that code changes in the develop branch remain stable and pass all tests.